### PR TITLE
Fix build issues due to maturin & py03 versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 name = "tantivy"
 crate-type = ["cdylib"]
 
+[build-dependencies]
+pyo3-build-config = "0.15.1"
+
 [dependencies]
 chrono = "0.4.19"
 tantivy = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.9.0"
 futures = "0.3.5"
 
 [dependencies.pyo3]
-version = "0.13.2"
+version = "0.14.5"
 features = ["extension-module"]
 
 [package.metadata.maturin]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,23 @@
+ifeq ($(shell UNAME),Darwin)
+  EXT := dylib
+else
+  EXT := so
+endif
+
 source_files := $(wildcard src/*.rs)
 
-all: tantivy/tantivy.so
+all: tantivy/tantivy.$(EXT)
 
 PHONY: test format
 
-test: tantivy/tantivy.so
+test: tantivy/tantivy.$(EXT)
 	python3 -m pytest
 
 format:
 	rustfmt src/*.rs
 
-tantivy/tantivy.so: target/debug/libtantivy.so
-	cp target/debug/libtantivy.so tantivy/tantivy.so
+tantivy/tantivy.$(EXT): target/debug/libtantivy.$(EXT)
+	cp target/debug/libtantivy.$(EXT) tantivy/tantivy.so
 
-target/debug/libtantivy.so: $(source_files)
+target/debug/libtantivy.$(EXT): $(source_files)
 	cargo build

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-maturin = ">=0.7.7"
+maturin = ">=0.12.0"
 pytest = ">=4.0"
 e1839a8 = {path = "."}
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+  pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
This PR bump maturin and py03 versions to latests. It also update the Makefile to properly run `make test` on MacOS.

This should fix https://github.com/quickwit-inc/tantivy-py/issues/33

Note that to successfully build on a MacOS M1, you may need the following rustflags defined in ~/.cargo/config 
```
[target.aarch64-apple-darwin]
rustflags = [
  "-C", "link-arg=-undefined",
  "-C", "link-arg=dynamic_lookup",
]
```

Output from `make test`:
```
$> make test
cp target/debug/libtantivy.dylib tantivy/tantivy.so
python3 -m pytest
================================= test session starts ==================================
platform darwin -- Python 3.9.7, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Users/nicolas/Documents/git/tantivy-py
collected 21 items                                                                     

tests/tantivy_test.py .....................                                      [100%]

================================== 21 passed in 3.37s ==================================
```