### PR TITLE
feat: use github actions for basic ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Check Formatting
+        run: rustfmt --check src/*rs
+
+  Test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.7
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: pip install pipenv
+      - run: pipenv install --dev
+      - run: pipenv run maturin develop
+      - run: pipenv run pytest -v tests


### PR DESCRIPTION
travis has been dead to oss for a while. use github actions

extracted from an integration branch for other extant prs, that branch / fork has other ci changes (use python lint/formatters ala flake8/black)
but thought it would be good to start with something minimal and also to verify project health.

https://github.com/kapilt/tantivy-py/pull/1

